### PR TITLE
Fix CDK synth TypeScript compilation issues - Issue #2

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -70,6 +70,8 @@ phases:
       - |
         if [ -f "cdk.json" ] || [ -f "infrastructure/cdk.json" ]; then
           echo "Validating CDK application..."
+          echo "Building TypeScript first..."
+          npm run build
           cdk synth --quiet
         else
           echo "No CDK app found yet - this will be created in future issues"

--- a/infrastructure/bin/ragtime.ts
+++ b/infrastructure/bin/ragtime.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/// <reference types="node" />
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { RagTimeCDKToolkitStack } from '../lib/ragtime-toolkit-stack';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": [
       "es2020"
     ],
+    "types": ["node"],
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Summary
Fixes CDK synth failing in CodeBuild due to TypeScript compilation errors for missing Node.js types.

## Problem
The CodeBuild pipeline was failing during the `cdk synth` step with the following error:
```
TSError: ⨯ Unable to compile TypeScript:
infrastructure/bin/ragtime.ts(11,17): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
```

## Solution
1. **Added explicit Node.js types reference** to `infrastructure/bin/ragtime.ts`
2. **Configured tsconfig.json** to include Node.js types in the types array
3. **Updated buildspec.yml** to compile TypeScript before running CDK synth

## Changes Made
- Added `/// <reference types="node" />` directive to ragtime.ts
- Added `"types": ["node"]` to tsconfig.json compilerOptions
- Modified buildspec.yml to run `npm run build` before `cdk synth`

## Testing
✅ Local TypeScript compilation: `npm run build` - SUCCESS
✅ Local CDK synthesis: `npx cdk synth --quiet` - SUCCESS
```
Successfully synthesized to /home/manish/code/RagTime/cdk.out
Supply a stack id (RagTimeCDKToolkit, RagTimePipeline, RagTimeInfrastructure-dev) to display its template.
```

## GitHub Actions/CodeBuild
This PR should enable CodeBuild to successfully:
1. Install dependencies including @types/node
2. Compile TypeScript without errors
3. Run `cdk synth` successfully
4. Report status back to GitHub PR checks

Resolves Issue #2