### PR TITLE
Fix CORS canary status code validation to accept HTTP 204

### DIFF
--- a/infrastructure/lib/nested/ragtime-monitoring-stack.ts
+++ b/infrastructure/lib/nested/ragtime-monitoring-stack.ts
@@ -216,7 +216,7 @@ const corsTestBlueprint = async function () {
         };
         
         const req = https.request(options, (res) => {
-            if (res.statusCode !== 200) {
+            if (res.statusCode !== 200 && res.statusCode !== 204) {
                 reject(new Error(\`CORS preflight failed with status: \${res.statusCode}\`));
                 return;
             }


### PR DESCRIPTION
## Summary
- Fixed CORS canary to accept both HTTP 200 and 204 status codes for OPTIONS preflight requests
- API Gateway correctly returns HTTP 204 (No Content) for OPTIONS requests per RFC 7231
- Resolves failing CORS canary that was incorrectly treating valid 204 responses as failures

## Test plan
- [x] Build and compile TypeScript without errors  
- [x] Verify the CORS canary code change only affects the status code validation
- [ ] Deploy to staging/dev environment to test canary passes with 204 responses
- [ ] Monitor CloudWatch Synthetics to confirm canary success rate improves

🤖 Generated with [Claude Code](https://claude.ai/code)